### PR TITLE
Silence -Wstringop-truncate compilwer warnings

### DIFF
--- a/examples/ini_dump.c
+++ b/examples/ini_dump.c
@@ -11,7 +11,7 @@ static int dumper(void* user, const char* section, const char* name,
 
     if (strcmp(section, prev_section)) {
         printf("%s[%s]\n", (prev_section[0] ? "\n" : ""), section);
-        strncpy(prev_section, section, sizeof(prev_section));
+        strncpy(prev_section, section, sizeof(prev_section) - 1);
         prev_section[sizeof(prev_section) - 1] = '\0';
     }
     printf("%s = %s\n", name, value);

--- a/ini.c
+++ b/ini.c
@@ -70,7 +70,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }

--- a/tests/unittest.c
+++ b/tests/unittest.c
@@ -29,7 +29,7 @@ int dumper(void* user, const char* section, const char* name,
     User = *((int*)user);
     if (strcmp(section, Prev_section)) {
         printf("... [%s]\n", section);
-        strncpy(Prev_section, section, sizeof(Prev_section));
+        strncpy(Prev_section, section, sizeof(Prev_section) - 1);
         Prev_section[sizeof(Prev_section) - 1] = '\0';
     }
 

--- a/tests/unittest_string.c
+++ b/tests/unittest_string.c
@@ -14,7 +14,7 @@ int dumper(void* user, const char* section, const char* name,
     User = *((int*)user);
     if (strcmp(section, Prev_section)) {
         printf("... [%s]\n", section);
-        strncpy(Prev_section, section, sizeof(Prev_section));
+        strncpy(Prev_section, section, sizeof(Prev_section) - 1);
         Prev_section[sizeof(Prev_section) - 1] = '\0';
     }
     printf("... %s=%s;\n", name, value);


### PR DESCRIPTION
In FeralInteractive/gamemode#122 I added a bunch of new compiler warnings, including `-Wstringop-truncate`. This commit is fixing the fall-out.

When using strncpy (buf, source, sizeof (buf)); the compiler will
issue a warning even if 'buf' is then properly terminated via
buf[sizeof (buf) - 1] = '\0'. Usage of 'sizeof (buf) -1' within
the strncpy will silence the warning.
